### PR TITLE
Implementing CsvHeaderConverter

### DIFF
--- a/src/CsvHeaderConverter.php
+++ b/src/CsvHeaderConverter.php
@@ -1,0 +1,46 @@
+<?php
+
+/**
+ * This file is part of plumphp/plum-csv.
+ *
+ * (c) Florian Eckerstorfer <florian@eckerstorfer.co>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Plum\PlumCsv;
+
+use Plum\Plum\Converter\ConverterInterface;
+
+/**
+ * CsvHeaderConverter
+ *
+ * @package   Plum\PlumCsv
+ * @author    Sebastian Göttschkes <sebastian.goettschkes@googlemail.com>
+ * @copyright 2015 Florian Eckerstorfer
+ */
+class CsvHeaderConverter implements ConverterInterface
+{
+    /** @var string[]|null */
+    private $header = null;
+
+    /**
+     * @inheritdoc
+     */
+    public function convert($item)
+    {
+        if ($this->header === null) {
+            $this->header = $item;
+
+            return $item;
+        }
+
+        $newItem = [];
+        foreach ($item AS $key => $value) {
+            $newItem[$this->header[$key]] = $value;
+        }
+
+        return $newItem;
+    }
+}

--- a/tests/CsvHeaderConverterTest.php
+++ b/tests/CsvHeaderConverterTest.php
@@ -1,0 +1,50 @@
+<?php
+
+/**
+ * This file is part of plumphp/plum-csv.
+ *
+ * (c) Florian Eckerstorfer <florian@eckerstorfer.co>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Plum\PlumCsv;
+
+/**
+ * CsvHeaderConverterTest
+ *
+ * @package   Plum\PlumCsv
+ * @author    Sebastian Göttschkes <sebastian.goettschkes@googlemail.com>
+ * @copyright 2015 Florian Eckerstorfer
+ * @group     unit
+ */
+class CsvHeaderConverterTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @test
+     * @covers Plum\PlumCsv\CsvHeaderConverter::convert()
+     */
+    public function convertFirstLine()
+    {
+        $headerConverter = new CsvHeaderConverter();
+        $header = ['Headline #1', '#2', '3'];
+
+        $this->assertSame($header, $headerConverter->convert($header));
+
+        return $headerConverter;
+    }
+
+    /**
+     * @test
+     * @depends convertFirstLine
+     * @covers Plum\PlumCsv\CsvHeaderConverter::convert()
+     */
+    public function convertSecondLine($headerConverter)
+    {
+        $secondLine = $headerConverter->convert(['Data field #1', 'foo', 'bar']);
+
+        $this->assertSame('Data field #1', $secondLine['Headline #1']);
+        $this->assertSame('bar', $secondLine['3']); 
+    }
+}

--- a/tests/CsvTest.php
+++ b/tests/CsvTest.php
@@ -1,0 +1,51 @@
+<?php
+
+/**
+ * This file is part of plumphp/plum-csv.
+ *
+ * (c) Florian Eckerstorfer <florian@eckerstorfer.co>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Plum\PlumCsv;
+
+use org\bovigo\vfs\vfsStream;
+use Plum\Plum\Workflow;
+
+/**
+ * CsvHeaderConverterTest
+ *
+ * @package   Plum\PlumCsv
+ * @author    Sebastian Göttschkes <sebastian.goettschkes@googlemail.com>
+ * @copyright 2015 Florian Eckerstorfer
+ * @group     functional
+ */
+class CsvTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @test
+     */
+    public function testWorkflow()
+    {
+        vfsStream::setup(
+            'fixtures',
+            null,
+            ['foo.csv' => 'Test,Data,Column 3'."\n".'1,Something,Column 3'."\n".'2,Another Thing,Column 3'."\n"]
+        );
+
+        $reader = new CsvReader(vfsStream::url('fixtures/foo.csv'));
+        $converter = new CsvHeaderConverter();
+        $writer = new CsvWriter(vfsStream::url('fixtures/bar.csv'));
+
+        $workflow = new Workflow();
+        $workflow->addConverter($converter)->addWriter($writer);
+        $result = $workflow->process($reader);
+
+        $this->assertSame(0, $result->getErrorCount());
+        $this->assertSame(3, $result->getItemWriteCount());
+        $this->assertSame(3, $result->getReadCount());
+        $this->assertSame(3, $result->getWriteCount());
+    }
+}


### PR DESCRIPTION
As discussed in #4, I implemented a Converter which takes the first row and stores the values for each cell. It then returns an array where the keys are the cells from the first row and the values are the cells from the current row. The example from my opening post in issue #4 is a good example of how it works.

Currently, the Converter also returns the header row, left unchanged. This is because returning `null` raises an error inside the Workflow (and registers an Exception within the `Result`) and returning an empty array means the following steps in the workflow must be prepared to work with an empty array as well.

My idea here is to also create a `CsvHeaderFilter` which returns false for the first item it gets and true for every following one, filtering only the header. This one can be used with or without the `CsvHeaderConverter` and might be usefull in other circumstances as well!
